### PR TITLE
Add a way to manually disable the node

### DIFF
--- a/templates/clustercheck.erb
+++ b/templates/clustercheck.erb
@@ -15,6 +15,20 @@ if [[ $1 == '-h' || $1 == '--help' ]];then
     exit
 fi
 
+# if the disabled file is present, return 503. This allows
+# admins to manually remove a node from a cluster easily.
+if [ -e "/var/tmp/clustercheck.disabled" ]; then
+    # Shell return-code is 1
+    echo -en "HTTP/1.1 503 Service Unavailable\r\n"
+    echo -en "Content-Type: text/plain\r\n"
+    echo -en "Connection: close\r\n"
+    echo -en "Content-Length: 51\r\n"
+    echo -en "\r\n"
+    echo -en "Percona XtraDB Cluster Node is manually disabled.\r\n"
+    sleep 0.1
+    exit 1
+fi
+
 MYSQL_USERNAME="<%= @status_user %>"
 MYSQL_PASSWORD="<%= @status_password %>"
 MYSQL_HOST="<%= @status_host %>"


### PR DESCRIPTION
By dropping a file into /var/tmp the node can be manually removed from
the cluster. This enables a simple way to remove a node from the cluster
for maintenance.

This change has been merged into the percona repo which is upstream for 
the clustercheck script.