### PR TITLE
Dependency errors when not setting galera_master

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -155,10 +155,10 @@ class galera(
     $my_cnf = "[client]\r\nuser=root\r\nhost=localhost\r\npassword='${root_password}'\r\n"
 
     exec { "create ${::root_home}/.my.cnf":
-      command => "/bin/echo -e \"$my_cnf\" > ${::root_home}/.my.cnf",
+      command => "/bin/echo -e \"${my_cnf}\" > ${::root_home}/.my.cnf",
       onlyif  => [
         "/usr/bin/mysql --user=root --password=${root_password} -e 'select count(1);'",
-        "/usr/bin/test `/bin/cat ${::root_home}/.my.cnf | /bin/grep -c \"password='$root_password'\"` -eq 0",
+        "/usr/bin/test `/bin/cat ${::root_home}/.my.cnf | /bin/grep -c \"password='${root_password}'\"` -eq 0",
         ],
       require => [Service['mysqld']],
       before  => [Class['mysql::server::root_password']],


### PR DESCRIPTION
When I did a puppet run without setting the galera_master. The first node completing the puppet run could login to mysql and set the root password. Nodes running puppet after the first node, failed because they couldn't login with an empty password and /root/.my.cnf couldn't be created because of dependency errors. (This was also the case when trying to change the root password after the cluster was setup)

    Error: Could not prefetch mysql_grant provider 'mysql': Execution of '/usr/bin/mysql -NBe SELECT CONCAT(User, '@',Host) AS User FROM mysql.user' returned 1: ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: NO)
    //Mysql::Server::Root_password/File[/root/.my.cnf] 	Skipping because of failed dependencies

We implemented the following solution. The exec creates a simple /root/.my.cnf if following conditions are met:

  * the given root password can login to mysql, this is done so that the first node can login with a empty password to set the password for the root user.
  * the root password isn't already set in /root/.my.cnf, to make sure that the exec isn't always executed.

With this solution all nodes completed the puppet run successful, without setting a galera_master.