### PR TITLE
Fix debian.cnf dependency

### DIFF
--- a/manifests/debian.pp
+++ b/manifests/debian.pp
@@ -46,4 +46,7 @@ class galera::debian {
       before    => Service['mysql']
     }
   }
+  # Ensure mysql server is installed before writing debian.cnf, since the
+  # package will create /etc/mysql
+  Package['mysql-server'] -> File['/etc/mysql/debian.cnf']
 }


### PR DESCRIPTION
This adds a dependency to ensure the mysql-server package is installed
before debian.cnf is written.  This is needed because the /etc/mysql
directory is created by the package and won't exist until it is
installed.