### PR TITLE
Change debian.cnf after stopping the service

### DIFF
--- a/manifests/debian.pp
+++ b/manifests/debian.pp
@@ -12,12 +12,12 @@ class galera::debian {
   # package install, so kill it if the package is
   # installed during this puppet run
   exec { 'clean_up_ubuntu':
-      command       => 'service mysql stop',
-      path          => '/usr/bin:/bin:/usr/sbin:/sbin',
-      refreshonly   => true,
-      subscribe     => Package['mysql-server'],
-      before        =>  Class['mysql::server::config'],
-      require       => Class['mysql::server::install'],
+    command     => 'service mysql stop',
+    path        => '/usr/bin:/bin:/usr/sbin:/sbin',
+    refreshonly => true,
+    subscribe   => Package['mysql-server'],
+    before      => Class['mysql::server::config'],
+    require     => Class['mysql::server::install'],
   }
 
   if ($::fqdn == $galera::galera_master) {
@@ -27,23 +27,26 @@ class galera::debian {
       ensure        => 'present',
       password_hash => mysql_password($galera::deb_sysmaint_password),
       provider      => 'mysql',
-      require       => File['/root/.my.cnf']
+      require       => File['/root/.my.cnf'],
     }
 
     file { '/etc/mysql/debian.cnf':
-      ensure    => present,
-      owner     => 'mysql',
-      group     => 'mysql',
-      content   => template('galera/debian.cnf.erb'),
-      require   => Mysql_user['debian-sys-maint@localhost']
+      ensure  => present,
+      owner   => 'mysql',
+      group   => 'mysql',
+      content => template('galera/debian.cnf.erb'),
+      require => Mysql_user['debian-sys-maint@localhost'],
     }
   } else {
+    # Ensure this file is changed only after stopping the service or
+    # said service stop operation will fail
     file { '/etc/mysql/debian.cnf':
-      ensure    => present,
-      owner     => 'mysql',
-      group     => 'mysql',
-      content   => template('galera/debian.cnf.erb'),
-      before    => Service['mysql']
+      ensure  => present,
+      owner   => 'mysql',
+      group   => 'mysql',
+      content => template('galera/debian.cnf.erb'),
+      require => Exec['clean_up_ubuntu'],
+      before  => Service['mysql'],
     }
   }
   # Ensure mysql server is installed before writing debian.cnf, since the


### PR DESCRIPTION
There exists a race where debian.cnf gets changed on a non-master node
before the service is stopped post install of the galera package.  The
end result is that the service stop fails due to the password changing.
This change also fixes some puppet lint errors in the affected file.