### PR TITLE
Fix clustercheck

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,9 @@
 #
 # === Parameters
 #
+# [*status_password*]
+#  (required) The password of the status check user
+#
 # [*galera_servers*]
 #   (optional) A list of IP addresses of the nodes in
 #   the galera cluster
@@ -122,6 +125,7 @@ class galera(
   $galera_package_name              = undef,
   $client_package_name              = undef,
   $package_ensure                   = 'installed',
+  $status_password                  = undef,
 )
 {
   if $configure_repo {

--- a/manifests/status.pp
+++ b/manifests/status.pp
@@ -59,7 +59,7 @@ class galera::status (
   mysql_grant { "${status_user}@${status_allow}/*.*":
     ensure     => 'present',
     options    => [ 'GRANT' ],
-    privileges => [ 'SELECT' ],
+    privileges => [ 'USAGE' ],
     table      => '*.*',
     user       => "${status_user}@${status_allow}",
     before     => Anchor['mysql::server::end']

--- a/manifests/status.pp
+++ b/manifests/status.pp
@@ -65,9 +65,17 @@ class galera::status (
     before     => Anchor['mysql::server::end']
   }
 
+  user{'clustercheck':
+    shell  => '/bin/false',
+    home   => '/var/empty',
+    before => File['/usr/local/bin/clustercheck'],
+    }
+
   file { '/usr/local/bin/clustercheck':
     content => template('galera/clustercheck.erb'),
-    mode    => '0755',
+    owner   => 'clustercheck',
+    group   => 'clustercheck',
+    mode    => '0500',
     before  => Anchor['mysql::server::end'],
   }
 
@@ -81,13 +89,15 @@ class galera::status (
     before  => Anchor['mysql::server::end'],
   }
 
+
   xinetd::service { 'mysqlchk':
     server                  => '/usr/local/bin/clustercheck',
     port                    => $port,
-    user                    => 'nobody',
+    user                    => 'clustercheck',
     flags                   => 'REUSE',
     log_on_success          => '',
     log_on_success_operator => '=',
+    require                 => [ File['/usr/local/bin/clustercheck'], User['clustercheck'] ],
     before                  => Anchor['mysql::server::end'],
   }
 }

--- a/manifests/status.pp
+++ b/manifests/status.pp
@@ -38,7 +38,7 @@
 #  Defaults to -1
 #
 class galera::status (
-  $status_password  = undef,
+  $status_password  = $galera::status_password,
   $status_allow     = '%',
   $status_host      = 'localhost',
   $status_user      = 'clustercheck',

--- a/manifests/status.pp
+++ b/manifests/status.pp
@@ -6,8 +6,7 @@
 # === Parameters:
 #
 # [*status_password*]
-#  (optional) The password of the status check user
-#  Defaults to 'statuscheck!'
+#  (required) The password of the status check user
 #
 # [*status_allow*]
 #  (optional) The subnet to allow status checks from
@@ -39,7 +38,7 @@
 #  Defaults to -1
 #
 class galera::status (
-  $status_password  = 'statuscheck!',
+  $status_password  = undef,
   $status_allow     = '%',
   $status_host      = 'localhost',
   $status_user      = 'clustercheck',
@@ -47,6 +46,10 @@ class galera::status (
   $available_when_donor    = 0,
   $available_when_readonly = -1,
 ) {
+
+  if ! $status_password {
+    fail('galera::status::status_password unset. Please specify a password for the clustercheck MySQL user.')
+  }
 
   mysql_user { "${status_user}@${status_allow}":
     ensure          => 'present',

--- a/spec/classes/galera_debian_spec.rb
+++ b/spec/classes/galera_debian_spec.rb
@@ -4,7 +4,8 @@ describe 'galera::debian' do
 
   let :pre_condition do
     "class { 'galera':
-       galera_master => 'control1'
+       galera_master => 'control1',
+       status_password => 'nonempty'
     }"
   end
 

--- a/spec/classes/galera_init_spec.rb
+++ b/spec/classes/galera_init_spec.rb
@@ -22,6 +22,13 @@ describe 'galera' do
     }
   end
 
+  let :pre_condition do
+    "
+    class { 'galera::status':
+       status_password => 'nonempty'
+    }"
+  end
+
   shared_examples_for 'galera' do
     it { should contain_class('galera::params') }
     it { should contain_package(os_params[:nc_package_name]).with(:ensure => 'installed') }

--- a/spec/classes/galera_repo_spec.rb
+++ b/spec/classes/galera_repo_spec.rb
@@ -36,7 +36,8 @@ describe 'galera::repo' do
   let :pre_condition do
     "class { 'galera':
       configure_repo => false,
-    }"
+      status_password => 'nonblank'
+    } "
   end
 
   context 'on RedHat' do


### PR DESCRIPTION
This pull request fixes the following security issues in galera::status:

* Insecure default password (removed, class will now fail if no password is explicitely specified)
* Needlessly generous SELECT grant on *.* for the MySQL user (downgraded to USAGE)
* Needlessly generous 0755 permissions on /usr/local/bin/clustercheck (added dedicated clustercheck user, reduced permission mode to 0500 for user clustercheck)