### PR TITLE
Fixed default for validate::action

### DIFF
--- a/manifests/validate.pp
+++ b/manifests/validate.pp
@@ -31,7 +31,7 @@
 #
 # [*action*]
 # (optional) The mysql command to run
-#  Defaults to 'select user,host from mysql.user;'
+#  Defaults to 'select count(1);'
 #
 # [*catch*]
 # (optional) A string that if present indicates failure
@@ -47,7 +47,7 @@ class galera::validate(
   $host      = $galera::status::status_host,
   $retries   = 20,
   $delay     = 3,
-  $action    = 'select user,host from mysql.user;',
+  $action    = 'select count(1);',
   $catch     = 'ERROR',
   $inv_catch = 'undef'
 )


### PR DESCRIPTION
A select on table mysql will no longer work with the reduced grant level for
clustercheck introduced by 31ff546a4a84eaf9bb58227ef77c8330c9c5485f. Since
validation only ensures a working database connection anyway, 'select count(1);'
will suffice. Apologies for not testing this properly yesterday.