### PR TITLE
Updated MariaDB repo version to allow support for EL7 distros

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -41,7 +41,7 @@ class galera::repo(
 
   if ! $yum_mariadb_baseurl {
     $lower = downcase($::operatingsystem)
-    $real_yum_mariadb_baseurl = "http://yum.mariadb.org/5.5.35-upd/${lower}${::operatingsystemmajrelease}-amd64"
+    $real_yum_mariadb_baseurl = "http://yum.mariadb.org/5.5-galera/${lower}${::operatingsystemmajrelease}-amd64"
   } else {
     $real_yum_mariadb_baseurl = $yum_mariadb_baseurl
   }


### PR DESCRIPTION
Currently there is no easy way to run the module on EL7 with MariaDB due to the repo name used. This change tracks the MariaDB 5.5 repo across minor version changes including support for new distro versions such as EL7.