### PR TITLE
When using the MariaDB upstream repo in EL7 the log and pid directori…

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -105,7 +105,7 @@ class galera::repo(
           gpgkey    =>  $yum_mariadb_gpgkey,
           baseurl   => $real_yum_mariadb_baseurl
         }
-        if $::operatingsystemmajrelease >= '7' {
+        if versioncmp($::operatingsystemmajrelease, '7') >=0 {
           file { '/var/log/mariadb':
             ensure => 'directory',
             before => Class['mysql::server::config'],

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -105,6 +105,19 @@ class galera::repo(
           gpgkey    =>  $yum_mariadb_gpgkey,
           baseurl   => $real_yum_mariadb_baseurl
         }
+        if $::operatingsystemmajrelease >= '7' {
+          file { '/var/log/mariadb':
+            ensure => 'directory',
+            before => Class['mysql::server::config'],
+          }
+          file { '/var/run/mariadb':
+            ensure  => 'directory',
+            owner   => 'mysql',
+            group   => 'mysql',
+            require => Class['mysql::server::install'],
+            before  => Class['mysql::server::config'],
+          }
+        }
       }
     }
     default: {


### PR DESCRIPTION
When using EL7 & the upstream MariaDB repo (instead of pulling MariaDB from the base repo) the server will not start because the puppetlabs/mysql repo expects the following directories to be created by the package:

* /var/logs/mariadb
* /var/run/mariadb

but as you can guess from this pull request they are not.

The proposed solution perhaps isn't ideal but should work in that use case.