### PR TITLE
Fix Centos 7 issues

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 # Change this to swap between a centos and an ubuntu box
-box = 'precise64'
+box = 'puppetlabs/centos-7.0-64-puppet'
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
@@ -16,6 +16,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
     control1.vm.hostname = 'control1'
 
+    control1.vm.provision :shell do |shell|
+      shell.inline = 'cp -r /vagrant/modules/* /etc/puppet/modules; ' +
+               'ln -s /vagrant /etc/puppet/modules/galera'
+    end
+
     if box == 'precise64'
       control1.vm.provision :shell do |shell|
         script =
@@ -26,7 +31,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         "fi ;"
         shell.inline = script
       end
-    elsif  box == 'centos64'
+    elsif  (box == 'centos64' or box == 'puppetlabs/centos-7.0-64-puppet')
       control1.vm.provision :shell do |shell|
         shell.inline = "echo '192.168.99.101 control1.domain.name control1' > /etc/hosts;" +
                        "echo '127.0.0.1 control1 localhost localhost.localdomain localhost4 localhost4.localdomain4' >> /etc/hosts;" +
@@ -50,12 +55,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       end
     end
 
-    control1.vm.provision "puppet" do |puppet|
-      puppet.manifests_path = "examples"
-      puppet.manifest_file = "site.pp"
-      puppet.module_path = 'modules'
-      puppet.options = ['--pluginsync', '--debug']
+    if  (box == 'centos64' or box == 'puppetlabs/centos-7.0-64-puppet')
+      control1.vm.provision :shell do |shell|
+        shell.inline = 'puppet apply /vagrant/examples/centos7.pp'
+      end
+    else
+      control1.vm.provision :shell do |shell|
+        shell.inline = 'puppet apply /vagrant/examples/site.pp'
+      end
     end
+
   end
 
   config.vm.define "control2" do |control2|
@@ -66,6 +75,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
 
     control2.vm.hostname = 'control2'
+
+    control2.vm.provision :shell do |shell|
+      shell.inline = 'cp -r /vagrant/modules/* /etc/puppet/modules; ' +
+               'ln -s /vagrant /etc/puppet/modules/galera'
+    end
 
     if box == 'precise64'
       control2.vm.provision :shell do |shell|
@@ -79,7 +93,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       end
     end
 
-    if box == 'centos64'
+    if (box == 'centos64' or box == 'puppetlabs/centos-7.0-64-puppet')
       control2.vm.provision :shell do |shell|
         shell.inline = "echo '192.168.99.102 control2.domain.name control2' > /etc/hosts;" +
                        "echo '127.0.0.1 control2 localhost localhost.localdomain localhost4 localhost4.localdomain4' >> /etc/hosts;" +
@@ -103,11 +117,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       end
     end
 
-    control2.vm.provision "puppet" do |puppet|
-      puppet.manifests_path = "examples"
-      puppet.manifest_file = "site.pp"
-      puppet.module_path = 'modules'
-      puppet.options = ['--pluginsync']
+    if  (box == 'centos64' or box == 'puppetlabs/centos-7.0-64-puppet')
+      control2.vm.provision :shell do |shell|
+        shell.inline = 'puppet apply /vagrant/examples/centos7.pp'
+      end
+    else
+      control2.vm.provision :shell do |shell|
+        shell.inline = 'puppet apply /vagrant/examples/site.pp'
+      end
     end
+
   end
 end

--- a/examples/centos7.pp
+++ b/examples/centos7.pp
@@ -4,5 +4,6 @@ node default {
     galera_master   => 'control1.domain.name',
     vendor_type     => 'mariadb',
     status_password => 'mariadb',
+    bind_address    => $::ipaddress_enp0s8
   }
 }

--- a/manifests/mariadb.pp
+++ b/manifests/mariadb.pp
@@ -1,0 +1,22 @@
+# Class galera::mariadb
+
+# Sets some specific resources when using the mariadb distribution of
+# mysql-galera
+
+class galera::mariadb
+{
+  if versioncmp($::operatingsystemmajrelease, '7') >=0 {
+    file { '/var/log/mariadb':
+      ensure => 'directory',
+      before => Class['mysql::server::config'],
+    }
+
+    file { '/var/run/mariadb':
+      ensure  => 'directory',
+      owner   => 'mysql',
+      group   => 'mysql',
+      require => Class['mysql::server::install'],
+      before  => Class['mysql::server::config'],
+    }
+  }
+}

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -126,22 +126,10 @@ class galera::repo(
           descr    => $yum_mariadb_descr,
           enabled  => $yum_mariadb_enabled,
           gpgcheck => $yum_mariadb_gpgcheck,
-          gpgkey   =>  $yum_mariadb_gpgkey,
+          gpgkey   => $yum_mariadb_gpgkey,
           baseurl  => $real_yum_mariadb_baseurl
         }
-        if versioncmp($::operatingsystemmajrelease, '7') >=0 {
-          file { '/var/log/mariadb':
-            ensure => 'directory',
-            before => Class['mysql::server::config'],
-          }
-          file { '/var/run/mariadb':
-            ensure  => 'directory',
-            owner   => 'mysql',
-            group   => 'mysql',
-            require => Class['mysql::server::install'],
-            before  => Class['mysql::server::config'],
-          }
-        }
+        include galera::mariadb
       }
       elsif $repo_vendor == 'codership' {
         yumrepo { 'codership':

--- a/manifests/status.pp
+++ b/manifests/status.pp
@@ -40,7 +40,6 @@
 class galera::status (
   $status_password  = $galera::status_password,
   $status_allow     = '%',
-  $status_host      = 'localhost',
   $status_user      = 'clustercheck',
   $port             = 9200,
   $available_when_donor    = 0,

--- a/manifests/validate.pp
+++ b/manifests/validate.pp
@@ -44,7 +44,7 @@
 class galera::validate(
   $user      = $galera::status::status_user,
   $password  = $galera::status::status_password,
-  $host      = $galera::status::status_host,
+  $host      = $galera::bind_address,
   $retries   = 20,
   $delay     = 3,
   $action    = 'select count(1);',


### PR DESCRIPTION
Update vagrant file with centos 7 box and change example
manifest to support this case.

Move run and log directory definitions for mariadb into a
separate class to avoid dependency cycles.