### PR TITLE
Additional package as an ensure_resource

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -186,11 +186,12 @@ class galera(
   }
 
   if $galera::params::additional_packages {
-    package{ $galera::params::additional_packages:
+    ensure_resource(package, $galera::params::additional_packages,
+    {
       ensure  => $package_ensure,
       require => Anchor['mysql::server::start'],
       before  => Class['mysql::server::install']
-    }
+    })
   }
 
   Package<| title == 'mysql_client' |> {

--- a/spec/classes/galera_init_spec.rb
+++ b/spec/classes/galera_init_spec.rb
@@ -45,6 +45,7 @@ describe 'galera' do
       ) }
 
       it { should contain_package(os_params[:p_galera_package_name]).with(:ensure => 'installed') }
+      it { should contain_package(os_params[:p_additional_packages]).with(:ensure => 'installed') }
     end
 
     context 'when installing mariadb' do
@@ -56,6 +57,7 @@ describe 'galera' do
       ) }
 
       it { should contain_package(os_params[:m_galera_package_name]).with(:ensure => 'installed') }
+      it { should contain_package(os_params[:m_additional_packages]).with(:ensure => 'installed') }
     end
 
 
@@ -68,6 +70,7 @@ describe 'galera' do
       ) }
 
       it { should contain_package(os_params[:c_galera_package_name]).with(:ensure => 'installed') }
+      it { should contain_package(os_params[:c_additional_packages]).with(:ensure => 'installed') }
     end
 
     context 'when specifying package names' do
@@ -100,14 +103,17 @@ describe 'galera' do
         :p_galera_package_name => 'percona-xtradb-cluster-galera-2.x',
         :p_client_package_name => 'percona-xtradb-cluster-client-5.5',
         :p_libgalera_location  => '/usr/lib/libgalera_smm.so',
+        :p_additional_packages => 'percona-xtrabackup',
         :m_mysql_package_name  => 'mariadb-galera-server-5.5',
         :m_galera_package_name => 'galera',
         :m_client_package_name => 'mariadb-client-5.5',
         :m_libgalera_location  => '/usr/lib/galera/libgalera_smm.so',
+        :m_additional_packages => 'rsync',
         :c_mysql_package_name  => 'mysql-wsrep-5.5',
         :c_galera_package_name => 'galera-3',
         :c_client_package_name => 'mysql-wsrep-client-5.5',
         :c_libgalera_location  => '/usr/lib/libgalera_smm.so',
+        :c_additional_packages => 'rsync',
         :mysql_service_name    => 'mysql',
         :nc_package_name       => 'netcat',
       }
@@ -127,19 +133,22 @@ describe 'galera' do
         :p_galera_package_name => 'Percona-XtraDB-Cluster-galera-2',
         :p_client_package_name => 'Percona-XtraDB-Cluster-client-55',
         :p_libgalera_location  => '/usr/lib64/libgalera_smm.so',
+        :p_additional_packages => 'percona-xtrabackup',
         :m_mysql_package_name  => 'MariaDB-Galera-server',
         :m_galera_package_name => 'galera',
         :m_client_package_name => 'MariaDB-client',
         :m_libgalera_location  => '/usr/lib64/galera/libgalera_smm.so',
+        :m_additional_packages => 'rsync',
         :c_mysql_package_name  => 'mysql-wsrep-5.5',
         :c_galera_package_name => 'galera-3',
         :c_client_package_name => 'mysql-wsrep-client-5.5',
         :c_libgalera_location  => '/usr/lib64/galera-3/libgalera_smm.so',
+        :c_additional_packages => 'rsync',
         :mysql_service_name    => 'mysql',
         :nc_package_name       => 'nc',
       }
     end
-   it_configures 'galera'
+    it_configures 'galera'
   end
 
   context 'on RedHat 7 platforms' do
@@ -154,19 +163,21 @@ describe 'galera' do
         :p_galera_package_name => 'Percona-XtraDB-Cluster-galera-2',
         :p_client_package_name => 'Percona-XtraDB-Cluster-client-55',
         :p_libgalera_location  => '/usr/lib64/libgalera_smm.so',
+        :p_additional_packages => 'percona-xtrabackup',
         :m_mysql_package_name  => 'MariaDB-Galera-server',
         :m_galera_package_name => 'galera',
         :m_client_package_name => 'MariaDB-client',
         :m_libgalera_location  => '/usr/lib64/galera/libgalera_smm.so',
+        :m_additional_packages => 'rsync',
         :c_mysql_package_name  => 'mysql-wsrep-5.5',
         :c_galera_package_name => 'galera-3',
         :c_client_package_name => 'mysql-wsrep-client-5.5',
         :c_libgalera_location  => '/usr/lib64/galera-3/libgalera_smm.so',
+        :c_additional_packages => 'rsync',
         :mysql_service_name    => 'mysql',
         :nc_package_name       => 'nmap-ncat',
       }
     end
-   it_configures 'galera'
+    it_configures 'galera'
   end
 end
-


### PR DESCRIPTION
We control additional packages which can lead to duplicate resources

I think just ensuring the package is in the specified state is enough