### PR TITLE
Puppet future parser scope fix

### DIFF
--- a/manifests/debian.pp
+++ b/manifests/debian.pp
@@ -21,11 +21,15 @@ class galera::debian {
   }
 
   if ($::fqdn == $galera::galera_master) {
+    # Assign this locally so that it is in scope for the template below.
+    # Required for Puppet 4
+    $deb_sysmaint_password = $galera::deb_sysmaint_password
+
     # Debian sysmaint pw will be set on the master,
     # and needs to be consistent across the cluster.
     mysql_user { 'debian-sys-maint@localhost':
       ensure        => 'present',
-      password_hash => mysql_password($galera::deb_sysmaint_password),
+      password_hash => mysql_password($deb_sysmaint_password),
       provider      => 'mysql',
       require       => File['/root/.my.cnf'],
     }


### PR DESCRIPTION
In the future parser, the parent classes local variables aren't
available in templates.  To avoid that, we assign the
deb_sysmaint_password from the parent galera class to a local variable
so that the template will have access to it.