### PR TITLE
Move boostrap check from nc to nmap

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,11 +50,6 @@ class galera::params {
     }
     $osr_array = split($::operatingsystemrelease,'[\/\.]')
     $distrelease = $osr_array[0]
-    if versioncmp($distrelease, '7') >= 0 or $galera::vendor_type == 'osp5' {
-      $nc_package_name = 'nmap-ncat'
-    } else {
-      $nc_package_name = 'nc'
-    }
 
 
     $rundir = '/var/run/mysqld'
@@ -62,7 +57,6 @@ class galera::params {
   }
   elsif ($::osfamily == 'Debian'){
     $mysql_service_name = 'mysql'
-    $nc_package_name = 'netcat'
     if $galera::vendor_type == 'percona' {
       $mysql_package_name_internal = 'percona-xtradb-cluster-server-5.5'
       $galera_package_name_internal = 'percona-xtradb-cluster-galera-2.x'

--- a/spec/classes/galera_init_spec.rb
+++ b/spec/classes/galera_init_spec.rb
@@ -31,7 +31,6 @@ describe 'galera' do
 
   shared_examples_for 'galera' do
     it { should contain_class('galera::params') }
-    it { should contain_package(os_params[:nc_package_name]).with(:ensure => 'installed') }
 
     context 'with default parameters' do
       it { should contain_class('galera::repo') }
@@ -115,7 +114,6 @@ describe 'galera' do
         :c_libgalera_location  => '/usr/lib/libgalera_smm.so',
         :c_additional_packages => 'rsync',
         :mysql_service_name    => 'mysql',
-        :nc_package_name       => 'netcat',
       }
     end
     it_configures 'galera'
@@ -145,7 +143,6 @@ describe 'galera' do
         :c_libgalera_location  => '/usr/lib64/galera-3/libgalera_smm.so',
         :c_additional_packages => 'rsync',
         :mysql_service_name    => 'mysql',
-        :nc_package_name       => 'nc',
       }
     end
     it_configures 'galera'
@@ -175,7 +172,6 @@ describe 'galera' do
         :c_libgalera_location  => '/usr/lib64/galera-3/libgalera_smm.so',
         :c_additional_packages => 'rsync',
         :mysql_service_name    => 'mysql',
-        :nc_package_name       => 'nmap-ncat',
       }
     end
     it_configures 'galera'


### PR DESCRIPTION
nc on RedHat based platforms no longer has the -z option,
so move to nmap instead. nmap was chosen over tcping since
I don't think tcping is in the standard base repos for
Centos, while nmap is in base, and also included in many
default installs.

This change will also affect Debian, but the result should only
be that the nmap package is installed - everything else should work
as before.

A nice side effect is the checking command is also a lot simpler,
since nmap accepts a list as input.