### PR TITLE
Update to use rspec-puppet facts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 group :development, :test do
   gem 'puppetlabs_spec_helper',  :require => false
   gem 'puppet-lint', '~> 0.3.2', :require => false
+  gem 'rspec-puppet-facts',      :require => false
   gem 'rake', '~> 10.1.1',       :require => false
   gem 'rspec', '< 2.99',         :require => false
   gem 'rspec-puppet',            :require => false

--- a/spec/classes/galera_debian_spec.rb
+++ b/spec/classes/galera_debian_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe 'galera::debian' do
-
   let :pre_condition do
     "class { 'galera':
        galera_master => 'control1',
@@ -9,61 +8,71 @@ describe 'galera::debian' do
     }"
   end
 
-  context 'with default parameters' do
-    let :facts do
-      {
-        :osfamily => 'Debian'
-      }
+  shared_examples_for 'galera on Debian' do
+    context 'with default parameters' do
+      it { should contain_exec('clean_up_ubuntu').with(
+        :command     => "service mysql stop",
+        :path        => "/usr/bin:/bin:/usr/sbin:/sbin",
+        :refreshonly => true,
+        :subscribe   => "Package[mysql-server]"
+      ) }
     end
-    it { should contain_exec('clean_up_ubuntu').with(
-      :command     => "service mysql stop",
-      :path        => "/usr/bin:/bin:/usr/sbin:/sbin",
-      :refreshonly => true,
-      :subscribe   => "Package[mysql-server]"
-    ) }
+
+    context 'when this node is the master' do
+      before(:each) do
+        facts.merge!({
+          :fqdn => 'control1',
+        })
+      end
+      let(:node) { 'control1' }
+
+      it { should contain_mysql_user('debian-sys-maint@localhost').with(
+        :ensure   => 'present',
+        :provider => 'mysql',
+        :require  => "File[/root/.my.cnf]"
+      ) }
+
+      it { should contain_file('/etc/mysql/debian.cnf').with(
+        :require => 'Mysql_user[debian-sys-maint@localhost]'
+      ) }
+
+      it { should_not contain_file('/etc/mysql/debian.cnf').with(
+        :before => 'Service[mysql]'
+      ) }
+    end
+
+    context 'when this node is a slave' do
+      before(:each) do
+        facts.merge!({
+          :fqdn => 'slave',
+        })
+      end
+      let(:node) { 'slave' }
+
+      it { should_not contain_mysql_user('debian-sys-maint@localhost').with(
+        :ensure   => 'present',
+        :provider => 'mysql',
+        :require  => "File[/root/.my.cnf]"
+      ) }
+
+      it { should_not contain_file('/etc/mysql/debian.cnf').with(
+        :require => 'Mysql_user[debian-sys-maint@localhost]'
+      ) }
+    end
   end
 
-  context 'when this node is the master' do
-    let :facts do
-      {
-        :fqdn => 'control1',
-        :osfamily => 'Debian'
-      }
+  on_supported_os.each do |os,facts|
+    context "on #{os}" do
+      let (:facts) do
+        facts.merge({})
+      end
+
+      case facts[:osfamily]
+      when 'Debian'
+        it_configures 'galera on Debian'
+      end
     end
-    let(:node) { 'control1' }
-
-    it { should contain_mysql_user('debian-sys-maint@localhost').with(
-      :ensure   => 'present',
-      :provider => 'mysql',
-      :require  => "File[/root/.my.cnf]"
-    ) }
-
-    it { should contain_file('/etc/mysql/debian.cnf').with(
-      :require => 'Mysql_user[debian-sys-maint@localhost]'
-    ) }
-
-    it { should_not contain_file('/etc/mysql/debian.cnf').with(
-      :before => 'Service[mysql]'
-    ) }
   end
 
-  context 'when this node is a slave' do
-    let :facts do
-      {
-        :fqdn => 'slave',
-        :osfamily => 'Debian'
-      }
-    end
-    let(:node) { 'slave' }
 
-    it { should_not contain_mysql_user('debian-sys-maint@localhost').with(
-      :ensure   => 'present',
-      :provider => 'mysql',
-      :require  => "File[/root/.my.cnf]"
-    ) }
-
-    it { should_not contain_file('/etc/mysql/debian.cnf').with(
-      :require => 'Mysql_user[debian-sys-maint@localhost]'
-    ) }
-  end
 end

--- a/spec/classes/galera_init_spec.rb
+++ b/spec/classes/galera_init_spec.rb
@@ -59,6 +59,10 @@ describe 'galera' do
       it { should contain_package(os_params[:m_additional_packages]).with(:ensure => 'installed') }
     end
 
+    context 'when using xtrabackup-v2' do
+      before { params.merge!( :wsrep_sst_method => 'xtrabackup-v2' ) }
+      it { should contain_package('percona-xtrabackup').with(:ensure => 'installed') }
+    end
 
     context 'when installing codership' do
       before { params.merge!( :vendor_type => 'codership') }
@@ -92,88 +96,53 @@ describe 'galera' do
     end
   end
 
-  context 'on Debian platforms' do
-    let :facts do
-      { :osfamily => 'Debian' }
-    end
+  on_supported_os.each do |os,facts|
+    context "on #{os}" do
+      let (:facts) do
+        facts.merge({ })
+      end
 
-    let :os_params do
-      { :p_mysql_package_name  => 'percona-xtradb-cluster-server-5.5',
-        :p_galera_package_name => 'percona-xtradb-cluster-galera-2.x',
-        :p_client_package_name => 'percona-xtradb-cluster-client-5.5',
-        :p_libgalera_location  => '/usr/lib/libgalera_smm.so',
-        :p_additional_packages => 'percona-xtrabackup',
-        :m_mysql_package_name  => 'mariadb-galera-server-5.5',
-        :m_galera_package_name => 'galera',
-        :m_client_package_name => 'mariadb-client-5.5',
-        :m_libgalera_location  => '/usr/lib/galera/libgalera_smm.so',
-        :m_additional_packages => 'rsync',
-        :c_mysql_package_name  => 'mysql-wsrep-5.5',
-        :c_galera_package_name => 'galera-3',
-        :c_client_package_name => 'mysql-wsrep-client-5.5',
-        :c_libgalera_location  => '/usr/lib/libgalera_smm.so',
-        :c_additional_packages => 'rsync',
-        :mysql_service_name    => 'mysql',
-      }
-    end
-    it_configures 'galera'
-  end
+      let (:os_params) do
+        if facts[:osfamily] == 'RedHat'
+          { :p_mysql_package_name  => 'Percona-XtraDB-Cluster-server-55',
+            :p_galera_package_name => 'Percona-XtraDB-Cluster-galera-2',
+            :p_client_package_name => 'Percona-XtraDB-Cluster-client-55',
+            :p_libgalera_location  => '/usr/lib64/libgalera_smm.so',
+            :p_additional_packages => 'rsync',
+            :m_mysql_package_name  => 'MariaDB-Galera-server',
+            :m_galera_package_name => 'galera',
+            :m_client_package_name => 'MariaDB-client',
+            :m_libgalera_location  => '/usr/lib64/galera/libgalera_smm.so',
+            :m_additional_packages => 'rsync',
+            :c_mysql_package_name  => 'mysql-wsrep-5.5',
+            :c_galera_package_name => 'galera-3',
+            :c_client_package_name => 'mysql-wsrep-client-5.5',
+            :c_libgalera_location  => '/usr/lib64/galera-3/libgalera_smm.so',
+            :c_additional_packages => 'rsync',
+            :mysql_service_name    => 'mysql',
+          }
+        elsif facts[:osfamily] == 'Debian'
+          { :p_mysql_package_name  => 'percona-xtradb-cluster-server-5.5',
+            :p_galera_package_name => 'percona-xtradb-cluster-galera-2.x',
+            :p_client_package_name => 'percona-xtradb-cluster-client-5.5',
+            :p_libgalera_location  => '/usr/lib/libgalera_smm.so',
+            :p_additional_packages => 'rsync',
+            :m_mysql_package_name  => 'mariadb-galera-server-5.5',
+            :m_galera_package_name => 'galera',
+            :m_client_package_name => 'mariadb-client-5.5',
+            :m_libgalera_location  => '/usr/lib/galera/libgalera_smm.so',
+            :m_additional_packages => 'rsync',
+            :c_mysql_package_name  => 'mysql-wsrep-5.5',
+            :c_galera_package_name => 'galera-3',
+            :c_client_package_name => 'mysql-wsrep-client-5.5',
+            :c_libgalera_location  => '/usr/lib/libgalera_smm.so',
+            :c_additional_packages => 'rsync',
+            :mysql_service_name    => 'mysql',
+          }
+        end
+      end
 
-  context 'on RedHat 6 platforms' do
-    let :facts do
-      { :osfamily => 'RedHat',
-        :operatingsystemrelease => '6.6',
-      }
+      it_configures 'galera'
     end
-
-    let :os_params do
-      { :p_mysql_package_name  => 'Percona-XtraDB-Cluster-server-55',
-        :p_galera_package_name => 'Percona-XtraDB-Cluster-galera-2',
-        :p_client_package_name => 'Percona-XtraDB-Cluster-client-55',
-        :p_libgalera_location  => '/usr/lib64/libgalera_smm.so',
-        :p_additional_packages => 'percona-xtrabackup',
-        :m_mysql_package_name  => 'MariaDB-Galera-server',
-        :m_galera_package_name => 'galera',
-        :m_client_package_name => 'MariaDB-client',
-        :m_libgalera_location  => '/usr/lib64/galera/libgalera_smm.so',
-        :m_additional_packages => 'rsync',
-        :c_mysql_package_name  => 'mysql-wsrep-5.5',
-        :c_galera_package_name => 'galera-3',
-        :c_client_package_name => 'mysql-wsrep-client-5.5',
-        :c_libgalera_location  => '/usr/lib64/galera-3/libgalera_smm.so',
-        :c_additional_packages => 'rsync',
-        :mysql_service_name    => 'mysql',
-      }
-    end
-    it_configures 'galera'
-  end
-
-  context 'on RedHat 7 platforms' do
-    let :facts do
-      { :osfamily => 'RedHat',
-        :operatingsystemrelease => '7.1',
-      }
-    end
-
-    let :os_params do
-      { :p_mysql_package_name  => 'Percona-XtraDB-Cluster-server-55',
-        :p_galera_package_name => 'Percona-XtraDB-Cluster-galera-2',
-        :p_client_package_name => 'Percona-XtraDB-Cluster-client-55',
-        :p_libgalera_location  => '/usr/lib64/libgalera_smm.so',
-        :p_additional_packages => 'percona-xtrabackup',
-        :m_mysql_package_name  => 'MariaDB-Galera-server',
-        :m_galera_package_name => 'galera',
-        :m_client_package_name => 'MariaDB-client',
-        :m_libgalera_location  => '/usr/lib64/galera/libgalera_smm.so',
-        :m_additional_packages => 'rsync',
-        :c_mysql_package_name  => 'mysql-wsrep-5.5',
-        :c_galera_package_name => 'galera-3',
-        :c_client_package_name => 'mysql-wsrep-client-5.5',
-        :c_libgalera_location  => '/usr/lib64/galera-3/libgalera_smm.so',
-        :c_additional_packages => 'rsync',
-        :mysql_service_name    => 'mysql',
-      }
-    end
-    it_configures 'galera'
   end
 end

--- a/spec/classes/galera_repo_spec.rb
+++ b/spec/classes/galera_repo_spec.rb
@@ -53,13 +53,7 @@ describe 'galera::repo' do
     } "
   end
 
-  context 'on RedHat' do
-    let :facts do
-      { :osfamily => 'RedHat',
-        :operatingsystemrelease => '6.6',
-      }
-    end
-
+  shared_examples_for 'galera::repo on RedHat' do
     context 'installing percona on redhat' do
       before { params.merge!( :repo_vendor => 'percona' ) }
       it { should contain_yumrepo('percona').with(
@@ -78,8 +72,8 @@ describe 'galera::repo' do
         :gpgcheck   => params[:yum_mariadb_gpgcheck],
         :gpgkey     => params[:yum_mariadb_gpgkey]
       ) }
-    end
 
+    end
     context 'installing codership on redhat' do
       before { params.merge!( :repo_vendor => 'codership' ) }
       it { should contain_yumrepo('codership').with(
@@ -91,50 +85,60 @@ describe 'galera::repo' do
     end
   end
 
-  context 'on Ubuntu' do
-    let :facts do
-      {
-        :osfamily        => 'Debian',
-        :operatingsystem => 'Ubuntu',
-        :lsbdistid       => 'Debian',
-        :lsbdistcodename => 'precise'
-      }
-    end
-
+  shared_examples_for 'galera::repo on Ubuntu' do
     context 'installing percona on debian' do
       before { params.merge!( :repo_vendor => 'percona' ) }
       it { should contain_apt__source('galera_percona_repo').with(
-        :location      => params[:apt_percona_repo_location],
-        :release       => params[:apt_percona_repo_release],
-        :repos         => params[:apt_percona_repo_repos],
-        :key           => params[:apt_percona_repo_key],
-        :key_server    => params[:apt_percona_repo_key_server],
-        :include_src   => params[:apt_percona_repo_include_src]
+          :location      => params[:apt_percona_repo_location],
+          :release       => params[:apt_percona_repo_release],
+          :repos         => params[:apt_percona_repo_repos],
+          :key           => params[:apt_percona_repo_key],
+          :key_server    => params[:apt_percona_repo_key_server],
+          :include_src   => params[:apt_percona_repo_include_src]
       ) }
     end
 
     context 'installing mariadb on debian' do
       before { params.merge!( :repo_vendor => 'mariadb' ) }
       it { should contain_apt__source('galera_mariadb_repo').with(
-        :location      => params[:apt_mariadb_repo_location],
-        :release       => params[:apt_mariadb_repo_release],
-        :repos         => params[:apt_mariadb_repo_repos],
-        :key           => params[:apt_mariadb_repo_key],
-        :key_server    => params[:apt_mariadb_repo_key_server],
-        :include_src   => params[:apt_mariadb_repo_include_src]
+          :location      => params[:apt_mariadb_repo_location],
+          :release       => params[:apt_mariadb_repo_release],
+          :repos         => params[:apt_mariadb_repo_repos],
+          :key           => params[:apt_mariadb_repo_key],
+          :key_server    => params[:apt_mariadb_repo_key_server],
+          :include_src   => params[:apt_mariadb_repo_include_src]
       ) }
     end
 
     context 'installing codership on debian' do
       before { params.merge!( :repo_vendor => 'codership' ) }
       it { should contain_apt__source('galera_codership_repo').with(
-        :location      => params[:apt_codership_repo_location],
-        :release       => params[:apt_codership_repo_release],
-        :repos         => params[:apt_codership_repo_repos],
-        :key           => params[:apt_codership_repo_key],
-        :key_server    => params[:apt_codership_repo_key_server],
-        :include_src   => params[:apt_codership_repo_include_src]
+          :location      => params[:apt_codership_repo_location],
+          :release       => params[:apt_codership_repo_release],
+          :repos         => params[:apt_codership_repo_repos],
+          :key           => params[:apt_codership_repo_key],
+          :key_server    => params[:apt_codership_repo_key_server],
+          :include_src   => params[:apt_codership_repo_include_src]
       ) }
     end
   end
+
+  on_supported_os.each do |os,facts|
+    context "on #{os}" do
+      let (:facts) do
+        facts.merge({ })
+      end
+
+      case facts[:osfamily]
+      when 'RedHat'
+        it_configures 'galera::repo on RedHat'
+      when 'Debian'
+        if facts[:operatingsystem] == 'Ubuntu'
+          it_configures 'galera::repo on Ubuntu'
+        end
+      end
+    end
+  end
+
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'shared_examples'
 
+require 'rspec-puppet-facts'
+include RspecPuppetFacts
+
 RSpec.configure do |c|
   c.alias_it_should_behave_like_to :it_configures, 'configures'
   c.alias_it_should_behave_like_to :it_raises, 'raises'


### PR DESCRIPTION
This change updates the tests for puppet-galera to use
puppet-rspec-facts for operating system fact management in the tests. By
using puppet-rspec-facts, we get a complete set of facts that fix many
of the previous test failures because facts were missing. By default
puppet-rspec-facts will use the versions from metadata.json for the
operating systes to test.