### PR TITLE
Add create_root_my_cnf flag

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,6 +57,11 @@
 #   (optional) The mysql root password.
 #   Defaults to 'test'
 #
+# [*create_root_my_cnf*]
+#   (optional) Flag to indicate if we should manage the root .my.cnf. Set this
+#   to false if you wish to manage your root .my.cnf file elsewhere.
+#   Defaults to true
+#
 # [*override_options*]
 #   (optional) Options to pass to mysql::server class.
 #   See the puppet-mysql doc for more information.
@@ -117,6 +122,7 @@ class galera(
   $wsrep_inc_state_transfer_port    = 4568,
   $wsrep_sst_method                 = 'rsync',
   $root_password                    = 'test',
+  $create_root_my_cnf               = true,
   $override_options                 = {},
   $vendor_type                      = 'percona',
   $configure_repo                   = true,
@@ -159,7 +165,7 @@ class galera(
 
   $options = mysql_deepmerge($galera::params::default_options, $override_options)
 
-  if ($root_password != 'UNSET') {
+  if ($create_root_my_cnf == true and $root_password != 'UNSET') {
     # Check if we can already login with the given password
     $my_cnf = "[client]\r\nuser=root\r\nhost=localhost\r\npassword='${root_password}'\r\n"
 
@@ -175,12 +181,13 @@ class galera(
   }
 
   class { 'mysql::server':
-    package_name     => $galera::params::mysql_package_name,
-    override_options => $options,
-    root_password    => $root_password,
-    service_enabled  => $service_enabled,
-    service_name     => $galera::params::mysql_service_name,
-    restart          => $mysql_restart,
+    package_name       => $galera::params::mysql_package_name,
+    override_options   => $options,
+    root_password      => $root_password,
+    create_root_my_cnf => $create_root_my_cnf,
+    service_enabled    => $service_enabled,
+    service_name       => $galera::params::mysql_service_name,
+    restart            => $mysql_restart,
   }
 
   file { $galera::params::rundir:

--- a/spec/classes/galera_init_spec.rb
+++ b/spec/classes/galera_init_spec.rb
@@ -64,6 +64,19 @@ describe 'galera' do
       it { should contain_package('percona-xtrabackup').with(:ensure => 'installed') }
     end
 
+    context 'when managing root .my.cnf' do
+      before { params.merge!( :create_root_my_cnf => true ) }
+      it { should contain_class('mysql::server').with(:create_root_my_cnf => true) }
+      it { should contain_exec("create #{facts[:root_home]}/.my.cnf") }
+    end
+
+    context 'when not managing root .my.cnf' do
+      before { params.merge!( :create_root_my_cnf => false ) }
+      it { should contain_class('mysql::server').with(:create_root_my_cnf => false) }
+      it { should_not contain_exec("create #{facts[:root_home]}/.my.cnf") }
+    end
+
+
     context 'when installing codership' do
       before { params.merge!( :vendor_type => 'codership') }
       it { should contain_class('mysql::server').with(


### PR DESCRIPTION
This change adds the ability to disable the management of the root
.my.cnf by the galera and mysql::server classes. This is useful if you
wish to manage your root .my.cnf elsewhere with custom settings. For
example if you wish to use the host parameter within the .my.cnf,
neither the galera or mysql::server classes support this. So you would
need to set create_root_my_cnf to false and manage the file prior to
pulling in the galera class.