### PR TITLE
Fix service title for debian

### DIFF
--- a/manifests/debian.pp
+++ b/manifests/debian.pp
@@ -50,7 +50,7 @@ class galera::debian {
       group   => 'mysql',
       content => template('galera/debian.cnf.erb'),
       require => Exec['clean_up_ubuntu'],
-      before  => Service['mysql'],
+      before  => Service['mysqld'],
     }
   }
   # Ensure mysql server is installed before writing debian.cnf, since the


### PR DESCRIPTION
The debian class references the service 'mysql' but the title is
actually 'mysqld'. This change switches from 'mysql' which was working
because that is the name of the service, to 'mysqld' which is the title
and will allow a user to override the service name.

Previously if you attempted to do something like:

```
Service <| title == 'mysqld' |> {
  name     => 'mysql.special',
  provider => 'pacemaker',
}
```

The debian class would throw an error because it could no longer find
Service['mysql']. This change updates the debian class to reference the
service by title like all of the other classes.