### PR TITLE
Replace puppetlabs/apt v1 with v2

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,7 +4,7 @@ fixtures:
     "mysql": "git://github.com/puppetlabs/puppetlabs-mysql.git"
     "apt":
       repo: "git://github.com/puppetlabs/puppetlabs-apt.git"
-      ref: '1.7.0'
+      ref: '2.2.2'
     "firewall": "git://github.com/puppetlabs/puppetlabs-firewall.git"
     "xinetd": "git://github.com/puppetlabs/puppetlabs-xinetd.git"
   symlinks:

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This module will massage puppetlabs-mysql into creating a mysql galera cluster. 
 
 ## Requirements
 
-This module was build against master of the following repos in early 2014, which corresponds to the listed version:
+This module depends on, at minimum, the following modules at the listed versions:
 
     puppetlabs-mysql    2.2.0
     puppetlabs-stdlib   4.1.0
 
     # If you're on debian and need the repo to be set
-    puppetlabs-apt      1.4.1
+    puppetlabs-apt      2.0.0
 
     # If you want the firewall to be configured for you
     puppetlabs-firewall 1.0.0

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -11,7 +11,7 @@ class galera::repo(
   $apt_percona_repo_location = 'http://repo.percona.com/apt/',
   $apt_percona_repo_release = $::lsbdistcodename,
   $apt_percona_repo_repos = 'main',
-  $apt_percona_repo_key = '1C4CBDCDCD2EFD2A',
+  $apt_percona_repo_key = '430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A',
   $apt_percona_repo_key_server = 'keys.gnupg.net',
   $apt_percona_repo_include_src = false,
 
@@ -22,7 +22,7 @@ class galera::repo(
   },
   $apt_mariadb_repo_release = $::lsbdistcodename,
   $apt_mariadb_repo_repos = 'main',
-  $apt_mariadb_repo_key = '1BB943DB',
+  $apt_mariadb_repo_key = '199369E5404BD5FC7D2FE43BCBCB082A1BB943DB',
   $apt_mariadb_repo_key_server = 'keys.gnupg.net',
   $apt_mariadb_repo_include_src = false,
 
@@ -33,7 +33,7 @@ class galera::repo(
   },
   $apt_codership_repo_release      = $::lsbdistcodename,
   $apt_codership_repo_repos        = 'main',
-  $apt_codership_repo_key          = 'BC19DDBA',
+  $apt_codership_repo_key          = '44B7345738EBDE52594DAD80D669017EBC19DDBA',
   $apt_codership_repo_key_server   = 'keyserver.ubuntu.com',
   $apt_codership_repo_include_src  = false,
 
@@ -72,30 +72,42 @@ class galera::repo(
       if ($::operatingsystem == 'Ubuntu') or ($::operatingsystem == 'Debian') {
         if ($repo_vendor == 'percona') {
           apt::source { 'galera_percona_repo':
-            location    => $apt_percona_repo_location,
-            release     => $apt_percona_repo_release,
-            repos       => $apt_percona_repo_repos,
-            key         => $apt_percona_repo_key,
-            key_server  => $apt_percona_repo_key_server,
-            include_src => $apt_percona_repo_include_src,
+            location => $apt_percona_repo_location,
+            release  => $apt_percona_repo_release,
+            repos    => $apt_percona_repo_repos,
+            key      => {
+              'id'     => $apt_percona_repo_key,
+              'server' => $apt_percona_repo_key_server,
+            },
+            include  => {
+              'src' => $apt_percona_repo_include_src,
+            },
           }
         } elsif ($repo_vendor == 'mariadb') {
           apt::source { 'galera_mariadb_repo':
-            location    => $apt_mariadb_repo_location,
-            release     => $apt_mariadb_repo_release,
-            repos       => $apt_mariadb_repo_repos,
-            key         => $apt_mariadb_repo_key,
-            key_server  => $apt_mariadb_repo_key_server,
-            include_src => $apt_mariadb_repo_include_src,
+            location => $apt_mariadb_repo_location,
+            release  => $apt_mariadb_repo_release,
+            repos    => $apt_mariadb_repo_repos,
+            key      => {
+              'id'     => $apt_mariadb_repo_key,
+              'server' => $apt_mariadb_repo_key_server,
+            },
+            include  => {
+              'src' => $apt_mariadb_repo_include_src,
+            },
           }
         } elsif ($repo_vendor == 'codership') {
           apt::source { 'galera_codership_repo':
-            location    => $apt_codership_repo_location,
-            release     => $apt_codership_repo_release,
-            repos       => $apt_codership_repo_repos,
-            key         => $apt_codership_repo_key,
-            key_server  => $apt_codership_repo_key_server,
-            include_src => $apt_codership_repo_include_src,
+            location => $apt_codership_repo_location,
+            release  => $apt_codership_repo_release,
+            repos    => $apt_codership_repo_repos,
+            key      => {
+              'id'     => $apt_codership_repo_key,
+              'server' => $apt_codership_repo_key_server,
+            },
+            include  => {
+              'src' => $apt_codership_repo_include_src,
+            },
           }
         }
       }

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 1.4.1 <= 1.7.0"
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     },
     {
       "name": "puppetlabs/mysql",

--- a/spec/classes/galera_repo_spec.rb
+++ b/spec/classes/galera_repo_spec.rb
@@ -9,21 +9,21 @@ describe 'galera::repo' do
       :apt_percona_repo_location     => 'http://repo.percona.com/apt/',
       :apt_percona_repo_release      => 'precise',
       :apt_percona_repo_repos        => 'main',
-      :apt_percona_repo_key          => '1C4CBDCDCD2EFD2A',
+      :apt_percona_repo_key          => '430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A',
       :apt_percona_repo_key_server   => 'keys.gnupg.net',
       :apt_percona_repo_include_src  => false,
 
       :apt_mariadb_repo_location     => 'http://mirror.aarnet.edu.au/pub/MariaDB/repo/5.5/ubuntu',
       :apt_mariadb_repo_release      => 'precise',
       :apt_mariadb_repo_repos        => 'main',
-      :apt_mariadb_repo_key          => '1BB943DB',
+      :apt_mariadb_repo_key          => '199369E5404BD5FC7D2FE43BCBCB082A1BB943DB',
       :apt_mariadb_repo_key_server   => 'keys.gnupg.net',
       :apt_mariadb_repo_include_src  => false,
 
       :apt_codership_repo_location     => 'http://releases.galeracluster.com/ubuntu',
       :apt_codership_repo_release      => 'precise',
       :apt_codership_repo_repos        => 'main',
-      :apt_codership_repo_key          => 'BC19DDBA',
+      :apt_codership_repo_key          => '44B7345738EBDE52594DAD80D669017EBC19DDBA',
       :apt_codership_repo_key_server   => 'keyserver.ubuntu.com',
       :apt_codership_repo_include_src  => false,
 
@@ -89,36 +89,48 @@ describe 'galera::repo' do
     context 'installing percona on debian' do
       before { params.merge!( :repo_vendor => 'percona' ) }
       it { should contain_apt__source('galera_percona_repo').with(
-          :location      => params[:apt_percona_repo_location],
-          :release       => params[:apt_percona_repo_release],
-          :repos         => params[:apt_percona_repo_repos],
-          :key           => params[:apt_percona_repo_key],
-          :key_server    => params[:apt_percona_repo_key_server],
-          :include_src   => params[:apt_percona_repo_include_src]
+          :location => params[:apt_percona_repo_location],
+          :release  => params[:apt_percona_repo_release],
+          :repos    => params[:apt_percona_repo_repos],
+          :key      => {
+              "id"     => params[:apt_percona_repo_key],
+              "server" => params[:apt_percona_repo_key_server]
+          },
+          :include  => {
+              "src" => params[:apt_percona_repo_include_src]
+          }
       ) }
     end
 
     context 'installing mariadb on debian' do
       before { params.merge!( :repo_vendor => 'mariadb' ) }
       it { should contain_apt__source('galera_mariadb_repo').with(
-          :location      => params[:apt_mariadb_repo_location],
-          :release       => params[:apt_mariadb_repo_release],
-          :repos         => params[:apt_mariadb_repo_repos],
-          :key           => params[:apt_mariadb_repo_key],
-          :key_server    => params[:apt_mariadb_repo_key_server],
-          :include_src   => params[:apt_mariadb_repo_include_src]
+          :location => params[:apt_mariadb_repo_location],
+          :release  => params[:apt_mariadb_repo_release],
+          :repos    => params[:apt_mariadb_repo_repos],
+          :key      => {
+              "id"     => params[:apt_mariadb_repo_key],
+              "server" => params[:apt_mariadb_repo_key_server]
+          },
+          :include  => {
+              "src" => params[:apt_mariadb_repo_include_src]
+          }
       ) }
     end
 
     context 'installing codership on debian' do
       before { params.merge!( :repo_vendor => 'codership' ) }
       it { should contain_apt__source('galera_codership_repo').with(
-          :location      => params[:apt_codership_repo_location],
-          :release       => params[:apt_codership_repo_release],
-          :repos         => params[:apt_codership_repo_repos],
-          :key           => params[:apt_codership_repo_key],
-          :key_server    => params[:apt_codership_repo_key_server],
-          :include_src   => params[:apt_codership_repo_include_src]
+          :location => params[:apt_codership_repo_location],
+          :release  => params[:apt_codership_repo_release],
+          :repos    => params[:apt_codership_repo_repos],
+          :key      => {
+              "id"     => params[:apt_codership_repo_key],
+              "server" => params[:apt_codership_repo_key_server]
+          },
+          :include  => {
+              "src" => params[:apt_codership_repo_include_src]
+          }
       ) }
     end
   end


### PR DESCRIPTION
This PR makes the galera module compatible with version 2.x of the puppetlabs/apt module.

The newest version of puppetlabs/apt supported by galera is very old (late 2014), and puppetlabs/apt 2.x still supports older Puppet versons, so it should be fine to use the latest version. By now a lot of sites should be using it, considering it was released almost a year a go at this point.