### PR TITLE
Fixes for problems when running on RedHat

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -254,7 +254,7 @@ class galera(
     exec { 'bootstrap_galera_cluster':
       command  => $galera::params::bootstrap_command,
       unless   => "nmap -p ${wsrep_group_comm_port} ${server_list} | grep -q '${wsrep_group_comm_port}/tcp open'",
-      require  => Class['mysql::server::config'],
+      require  => [Class['mysql::server::config'],Class['mysql::server::installdb']],
       before   => [Class['mysql::server::service'], Service['mysqld']],
       provider => shell,
       path     => '/usr/bin:/bin:/usr/sbin:/sbin'

--- a/manifests/status.pp
+++ b/manifests/status.pp
@@ -66,9 +66,9 @@ class galera::status (
   }
 
   mysql_user { "${status_user}@localhost":
-    ensure          => 'present',
-    password_hash   => mysql_password($status_password),
-    require         => [File['/root/.my.cnf'],Service['mysqld']]
+    ensure        => 'present',
+    password_hash => mysql_password($status_password),
+    require       => [File['/root/.my.cnf'],Service['mysqld']]
   } ->
   mysql_grant { "${status_user}@localhost/*.*":
     ensure     => 'present',
@@ -79,11 +79,11 @@ class galera::status (
     before     => Anchor['mysql::server::end']
   }
 
-  user{'clustercheck':
+  user{ 'clustercheck':
     shell  => '/bin/false',
     home   => '/var/empty',
     before => File['/usr/local/bin/clustercheck'],
-    }
+  }
 
   file { '/usr/local/bin/clustercheck':
     content => template('galera/clustercheck.erb'),

--- a/manifests/status.pp
+++ b/manifests/status.pp
@@ -65,6 +65,20 @@ class galera::status (
     before     => Anchor['mysql::server::end']
   }
 
+  mysql_user { "${status_user}@localhost":
+    ensure          => 'present',
+    password_hash   => mysql_password($status_password),
+    require         => [File['/root/.my.cnf'],Service['mysqld']]
+  } ->
+  mysql_grant { "${status_user}@localhost/*.*":
+    ensure     => 'present',
+    options    => [ 'GRANT' ],
+    privileges => [ 'USAGE' ],
+    table      => '*.*',
+    user       => "${status_user}@localhost",
+    before     => Anchor['mysql::server::end']
+  }
+
   user{'clustercheck':
     shell  => '/bin/false',
     home   => '/var/empty',

--- a/puppet-galera.iml
+++ b/puppet-galera.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/puppet-galera.iml
+++ b/puppet-galera.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>


### PR DESCRIPTION
-fix for clustercheck user, should also login to localhost
-fox for master start, adding dependency to bootstrap script

For clustercheck user, new user is created to login from localhost.Otherwise fail in puppet run.
Bootstrap script failed to start master, db init was not done, therefore added dependency explicitly.