### PR TITLE
Increase mysql module version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This module will massage puppetlabs-mysql into creating a mysql galera cluster. 
 
 This module depends on, at minimum, the following modules at the listed versions:
 
-    puppetlabs-mysql    2.2.0
+    puppetlabs-mysql    3.7.0
     puppetlabs-stdlib   4.1.0
 
     # If you're on debian and need the repo to be set

--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,7 @@
     },
     {
       "name": "puppetlabs/mysql",
-      "version_requirement": ">=2.2.0"
+      "version_requirement": ">=3.7.0"
     },
     {
       "name": "puppetlabs/firewall",


### PR DESCRIPTION
A new class in puppet-mysql that installs local dbs needs
to be handled before running bootstrap. This means the
dependency for bootstrap needs to accommodate that,
which was already merged, but the mysql module dependency
was not increased at the same time, causing errors.