### PR TITLE
Don't handle localhost allow twice

### DIFF
--- a/manifests/status.pp
+++ b/manifests/status.pp
@@ -51,18 +51,20 @@ class galera::status (
     fail('galera::status::status_password unset. Please specify a password for the clustercheck MySQL user.')
   }
 
-  mysql_user { "${status_user}@${status_allow}":
-    ensure        => 'present',
-    password_hash => mysql_password($status_password),
-    require       => [File['/root/.my.cnf'],Service['mysqld']]
-  } ->
-  mysql_grant { "${status_user}@${status_allow}/*.*":
-    ensure     => 'present',
-    options    => [ 'GRANT' ],
-    privileges => [ 'USAGE' ],
-    table      => '*.*',
-    user       => "${status_user}@${status_allow}",
-    before     => Anchor['mysql::server::end']
+  if $status_allow != 'localhost' {
+    mysql_user { "${status_user}@${status_allow}":
+      ensure        => 'present',
+      password_hash => mysql_password($status_password),
+      require       => [File['/root/.my.cnf'],Service['mysqld']]
+    } ->
+    mysql_grant { "${status_user}@${status_allow}/*.*":
+      ensure     => 'present',
+      options    => [ 'GRANT' ],
+      privileges => [ 'USAGE' ],
+      table      => '*.*',
+      user       => "${status_user}@${status_allow}",
+      before     => Anchor['mysql::server::end']
+    }
   }
 
   mysql_user { "${status_user}@localhost":


### PR DESCRIPTION
If status_allow is set to localhost, then we don't want to grant access
to localhost twice.  Check for that and skip adding it if detected.