### PR TITLE
Install xinetd after packages

### DIFF
--- a/manifests/status.pp
+++ b/manifests/status.pp
@@ -111,7 +111,10 @@ class galera::status (
     flags                   => 'REUSE',
     log_on_success          => '',
     log_on_success_operator => '=',
-    require                 => [ File['/usr/local/bin/clustercheck'], User['clustercheck'] ],
+    require                 => [
+      File['/usr/local/bin/clustercheck'],
+      User['clustercheck'],
+      Class['mysql::server::install']],
     before                  => Anchor['mysql::server::end'],
   }
 }


### PR DESCRIPTION
Install the xinetd service file for the status service after the server
package is installed.  The percona packages also include a mysqlchk
xinetd service, and without this change, the puppet module service file
gets installed first, then the package sets it aside.  If xinetd purging
is turned on, then the next puppet run will remove this.  Unfortunately
this means the first puppet run is not idempotent.