### PR TITLE
support version 5.6 with codership repo

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -73,9 +73,16 @@ class galera::params {
       $libgalera_location = '/usr/lib/galera/libgalera_smm.so'
     }
     elsif $galera::vendor_type == 'codership' {
-      $mysql_package_name_internal = 'mysql-wsrep-5.5'
-      $galera_package_name_internal = 'galera-3'
-      $client_package_name_internal = 'mysql-wsrep-client-5.5'
+      if $galera::vendor_version == '5.6' {
+        $mysql_package_name_internal = 'mysql-wsrep-5.6'
+        $galera_package_name_internal = 'galera-3'
+        $client_package_name_internal = 'mysql-wsrep-client-5.6'
+      }
+      else {
+        $mysql_package_name_internal = 'mysql-wsrep-5.5'
+        $galera_package_name_internal = 'galera-3'
+        $client_package_name_internal = 'mysql-wsrep-client-5.5'
+      }
       $libgalera_location = '/usr/lib/galera/libgalera_smm.so'
     }
     elsif $galera::vendor_type == 'osp5' {


### PR DESCRIPTION
Currently version 5.6 is only supported with Percona. This patch makes it possible to use it with Codership too. Tested on Ubuntu 14.04.