### PR TITLE
Allow Tinkering with mysqlchk Logging

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -125,6 +125,50 @@
 # [*manage_package_nmap*]
 #   (optional) Whether the package nmap should be installed
 #
+# [*status_password*]
+#  (required) The password of the status check user
+#
+# [*status_allow*]
+#  (optional) The subnet to allow status checks from
+#  Defaults to '%'
+#
+# [*status_host*]
+#  (optional) The cluster to add the cluster check user to
+#  Defaults to 'localhost'
+#
+# [*status_user*]
+#  (optional) The name of the user to use for status checks
+#  Defaults to 'clustercheck'
+#
+# [*status_port*]
+#  (optional) Port for cluster check service
+#  Defaults to 9200
+#
+# [*status_available_when_donor*]
+#  (optional) When set to 1, the node will remain in the cluster
+#  when it enters donor mode. A value of 0 will remove the node
+#  from the cluster.
+#  Defaults to 0
+#
+# [*status_available_when_readonly*]
+#  (optional) When set to 0, clustercheck will return a 503
+#  Service Unavailable if the node is in the read_only state,
+#  as defined by the "read_only" mysql variable. Values other
+#  than 0 have no effect.
+#  Defaults to -1
+#
+# [*status_log_on_success_operator*]
+#   (optional) Determines which operator xinetd uses to output logs on success
+#   Defaults to '='
+#
+# [*status_log_on_success*]
+#   (optional) Determines which fields xinetd will log on success
+#   Defaults to ''
+#
+# [*status_log_on_failure*]
+#   (optional) Determines which fields xinetd will log on failure
+#   Defaults to undef
+#
 class galera(
   $galera_servers                   = [$::ipaddress_eth1],
   $galera_master                    = $::fqdn,
@@ -154,6 +198,15 @@ class galera(
   $status_password                  = undef,
   $service_enabled                  = undef,
   $manage_package_nmap              = true,
+  $status_allow                     = '%',
+  $status_host                      = 'localhost',
+  $status_user                      = 'clustercheck',
+  $status_port                      = 9200,
+  $status_available_when_donor      = 0,
+  $status_available_when_readonly   = -1,
+  $status_log_on_success_operator   = '=',
+  $status_log_on_success            = '',
+  $status_log_on_failure            = undef,
 )
 {
   if $configure_repo {

--- a/manifests/validate.pp
+++ b/manifests/validate.pp
@@ -11,15 +11,15 @@
 #
 # [*user*]
 # (optional) The mysql user to use.
-#  Defaults to $galera::status::status_user
+#  Defaults to $galera::status_user
 #
 # [*password*]
 # (optional) The password for the mysql user.
-#  Defaults to $galera::status::status_password
+#  Defaults to $galera::status_password
 #
 # [*host*]
 # (optional) The mysql host to check.
-#  Defaults to $galera::status::status_host
+#  Defaults to $galera::status_host
 #
 # [*retries*]
 # (optional) Number of times to retry connection
@@ -42,8 +42,8 @@
 #  Defaults to undef
 #
 class galera::validate(
-  $user      = $galera::status::status_user,
-  $password  = $galera::status::status_password,
+  $user      = $galera::status_user,
+  $password  = $galera::status_password,
   $host      = $galera::bind_address,
   $retries   = 20,
   $delay     = 3,

--- a/spec/classes/galera_debian_spec.rb
+++ b/spec/classes/galera_debian_spec.rb
@@ -41,7 +41,7 @@ describe 'galera::debian' do
       ) }
 
       it { should contain_file('/etc/mysql/debian.cnf').with(
-        :user    => 'root',
+        :owner   => 'root',
         :group   => 'root',
         :mode    => '0600',
         :require => 'Mysql_user[debian-sys-maint@localhost]'


### PR DESCRIPTION
This aims to allow the reduction in verbosity from the mysqlchk xinetd process
for those of us who use it as a liveness check for haproxy.  I've also made the
check user a system account to avoid clashing with uid/gid >= 1000 which are
hard coded in some environments, altering this will not affect existing systems.

In order to get rspec tests working I've had to modernize the API slightly and
move `galera::status` parameters into the top level class.  As a result this
will need a new major revision as it's potentially a breaking change.