### PR TITLE
fix missing locally needed debian-sys-maint password in puppet4

### DIFF
--- a/manifests/debian.pp
+++ b/manifests/debian.pp
@@ -47,10 +47,11 @@ class galera::debian {
     require     => Class['mysql::server::install'],
   }
 
+  # Assign this locally so that it is in scope for the template below.
+  # Required for Puppet 4
+  $deb_sysmaint_password = $galera::deb_sysmaint_password
+
   if ($::fqdn == $galera::galera_master) {
-    # Assign this locally so that it is in scope for the template below.
-    # Required for Puppet 4
-    $deb_sysmaint_password = $galera::deb_sysmaint_password
 
     # Debian sysmaint pw will be set on the master,
     # and needs to be consistent across the cluster.


### PR DESCRIPTION
the deb_sysmaint_password variable is empty in puppet4 within the else part (not on the galera master)