### PR TITLE
Drop use of host discovery in nmap probe

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -319,7 +319,7 @@ class galera(
 
     exec { 'bootstrap_galera_cluster':
       command  => $galera::params::bootstrap_command,
-      unless   => "nmap -p ${wsrep_group_comm_port} ${server_list} | grep -q '${wsrep_group_comm_port}/tcp open'",
+      unless   => "nmap -Pn -p ${wsrep_group_comm_port} ${server_list} | grep -q '${wsrep_group_comm_port}/tcp open'",
       require  => Class['mysql::server::installdb'],
       before   => Service['mysqld'],
       provider => shell,


### PR DESCRIPTION
The nmap command used to probe for existing nodes before bootstrapping uses nmaps host discovery (basically an ICMP ping) before actually probing the port.

Since the nmap command used specifies the target hosts, this is unnecessary and will indeed fail if the network blocks ICMP.

eg:

    # nmap -p 4567 172.0.0.1
    Starting Nmap 6.47 ( http://nmap.org ) at 2017-02-10 15:40 UTC
    Note: Host seems down. If it is really up, but blocking our ping probes, try -Pn
    Nmap done: 1 IP address (0 hosts up) scanned in 3.15 seconds`

    # nmap -Pn -p 4567 172.0.0.1 
    Starting Nmap 6.47 ( http://nmap.org ) at 2017-02-10 15:44 GMT
    Nmap scan report for 172.0.0.1
    Host is up (0.00034s latency).
    PORT     STATE SERVICE
    4567/tcp open  tram
    Nmap done: 1 IP address (1 host up) scanned in 0.80 seconds`