### PR TITLE
fix mysqlchk entry in /etc/services on CentOS

### DIFF
--- a/manifests/status.pp
+++ b/manifests/status.pp
@@ -74,10 +74,12 @@ class galera::status {
   augeas { 'mysqlchk':
     context => '/files/etc/services',
     changes => [
+      "rm /files/etc/services/service-name[port = '${port}']",
       "set /files/etc/services/service-name[port = '${port}']/port ${port}",
       "set /files/etc/services/service-name[port = '${port}'] mysqlchk",
       "set /files/etc/services/service-name[port = '${port}']/protocol tcp",
     ],
+    onlyif => "match service-name[. = 'mysqlchk'] size == 0",
     before  => Anchor['mysql::server::end'],
   }
 


### PR DESCRIPTION
On CentOS (7) there is already a default entry in `/etc/services` for TCP 9200, thus an entry for `mysqlchk` will not be added, which in turn disables the xinetd configuration:

```
May 08 17:04:46 host.example.com xinetd[14896]: service/protocol combination not in /etc/services: mysqlchk/tcp
```

This patch makes sure to remove all existing entries before adding the new entry for `mysqlchk`. Augeas is smart enough to not do this on every run. :)

This will also solve the long-standing issue #15.