### PR TITLE
Correct typo in package name

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,8 +43,8 @@ class galera::params {
     }
     elsif $galera::vendor_type == 'codership' {
       if $galera::vendor_version == '5.6' {
-        $mysql_package_name_internal = 'mysql-wsrep-5.5'
-        $client_package_name_internal = 'mysql-wsrep-client-5.5'
+        $mysql_package_name_internal = 'mysql-wsrep-5.6'
+        $client_package_name_internal = 'mysql-wsrep-client-5.6'
       }
       elsif $galera::vendor_version == '5.7' {
         $mysql_package_name_internal = 'mysql-wsrep-5.7'


### PR DESCRIPTION
Codership 5.6 should install 5.6 not 5.5